### PR TITLE
New txid calculation

### DIFF
--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -23,7 +23,7 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter& filter)
 
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
-        const uint256& hash = block.vtx[i].GetHash();
+        const uint256& hash = block.vtx[i].GetScriptSigHash();
         if (filter.IsRelevantAndUpdate(block.vtx[i]))
         {
             vMatch.push_back(true);
@@ -49,7 +49,7 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, const std::set<uint256>& txids)
 
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
-        const uint256& hash = block.vtx[i].GetHash();
+        const uint256& hash = block.vtx[i].GetScriptSigHash();
         if (txids.count(hash))
             vMatch.push_back(true);
         else

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -55,7 +55,7 @@ uint256 CBlock::BuildMerkleTree(bool* fMutated) const
     vMerkleTree.clear();
     vMerkleTree.reserve(vtx.size() * 2 + 16); // Safe upper bound for the number of total nodes.
     for (std::vector<CTransaction>::const_iterator it(vtx.begin()); it != vtx.end(); ++it)
-        vMerkleTree.push_back(it->GetHash());
+        vMerkleTree.push_back(it->GetScriptSigHash());
     int j = 0;
     bool mutated = false;
     for (int nSize = vtx.size(); nSize > 1; nSize = (nSize + 1) / 2)

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -211,12 +211,17 @@ CMutableTransaction::CMutableTransaction(const CTransaction& tx) : nVersion(tx.n
 
 uint256 CMutableTransaction::GetHash() const
 {
-    return SerializeHash(*this);
+    return SerializeHash(*this, SER_GETHASH, this->nVersion);
 }
 
 void CTransaction::UpdateHash() const
 {
-    *const_cast<uint256*>(&hash) = SerializeHash(*this);
+    *const_cast<uint256*>(&hash) = SerializeHash(*this, SER_GETHASH, this->nVersion);
+}
+
+uint256 CTransaction::GetScriptSigHash() const
+{
+    return SerializeHash(*this, SER_GETHASH | SER_WITHSIG, this->nVersion);
 }
 
 CTransaction::CTransaction() : nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION), fOverwintered(false), nVersionGroupId(0), nExpiryHeight(0), vin(), vout(), nLockTime(0), valueBalance(0), vShieldedSpend(), vShieldedOutput(), vjoinsplit(), joinSplitPubKey(), joinSplitSig(), bindingSig() { }
@@ -357,15 +362,17 @@ std::string CTransaction::ToString() const
 {
     std::string str;
     if (!fOverwintered) {
-        str += strprintf("CTransaction(hash=%s, ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u)\n",
+        str += strprintf("CTransaction(txid=%s, hash=%s, ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u)\n",
             GetHash().ToString().substr(0,10),
+            GetScriptSigHash().ToString().substr(0,10),
             nVersion,
             vin.size(),
             vout.size(),
             nLockTime);
     } else if (nVersion >= SAPLING_MIN_TX_VERSION) {
-        str += strprintf("CTransaction(hash=%s, ver=%d, fOverwintered=%d, nVersionGroupId=%08x, vin.size=%u, vout.size=%u, nLockTime=%u, nExpiryHeight=%u, valueBalance=%u, vShieldedSpend.size=%u, vShieldedOutput.size=%u)\n",
+        str += strprintf("CTransaction(txid=%s, hash=%s, ver=%d, fOverwintered=%d, nVersionGroupId=%08x, vin.size=%u, vout.size=%u, nLockTime=%u, nExpiryHeight=%u, valueBalance=%u, vShieldedSpend.size=%u, vShieldedOutput.size=%u)\n",
             GetHash().ToString().substr(0,10),
+            GetScriptSigHash().ToString().substr(0,10),
             nVersion,
             fOverwintered,
             nVersionGroupId,
@@ -377,8 +384,9 @@ std::string CTransaction::ToString() const
             vShieldedSpend.size(),
             vShieldedOutput.size());
     } else if (nVersion >= 3) {
-        str += strprintf("CTransaction(hash=%s, ver=%d, fOverwintered=%d, nVersionGroupId=%08x, vin.size=%u, vout.size=%u, nLockTime=%u, nExpiryHeight=%u)\n",
+        str += strprintf("CTransaction(txid=%s, hash=%s, ver=%d, fOverwintered=%d, nVersionGroupId=%08x, vin.size=%u, vout.size=%u, nLockTime=%u, nExpiryHeight=%u)\n",
             GetHash().ToString().substr(0,10),
+            GetScriptSigHash().ToString().substr(0,10),
             nVersion,
             fOverwintered,
             nVersionGroupId,

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -627,7 +627,8 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
 
         entry.push_back(Pair("data", EncodeHexTx(tx)));
 
-        entry.push_back(Pair("hash", txHash.GetHex()));
+        entry.push_back(Pair("hash", tx.GetScriptSigHash().GetHex()));
+        entry.push_back(Pair("txid", txHash.GetHex()));
 
         UniValue deps(UniValue::VARR);
         BOOST_FOREACH (const CTxIn &in, tx.vin)

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -117,6 +117,7 @@ UniValue TxJoinSplitToJSON(const CTransaction& tx) {
 void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
 {
     entry.push_back(Pair("txid", tx.GetHash().GetHex()));
+    entry.push_back(Pair("hash", tx.GetScriptSigHash().GetHex()));
     entry.push_back(Pair("overwintered", tx.fOverwintered));
     entry.push_back(Pair("version", tx.nVersion));
     if (tx.fOverwintered) {
@@ -363,7 +364,7 @@ UniValue gettxoutproof(const UniValue& params, bool fHelp)
 
     unsigned int ntxFound = 0;
     BOOST_FOREACH(const CTransaction&tx, block.vtx)
-        if (setTxids.count(tx.GetHash()))
+        if (setTxids.count(tx.GetScriptSigHash()))
             ntxFound++;
     if (ntxFound != setTxids.size())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "(Not all) transactions not found in specified block");

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -179,6 +179,7 @@ enum
     SER_NETWORK         = (1 << 0),
     SER_DISK            = (1 << 1),
     SER_GETHASH         = (1 << 2),
+    SER_WITHSIG         = (1 << 3),
 };
 
 #define READWRITE(obj)      (::SerReadWrite(s, (obj), ser_action))

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3869,7 +3869,7 @@ int CMerkleTx::GetDepthInMainChainINTERNAL(const CBlockIndex* &pindexRet) const
     // Make sure the merkle branch connects to this block
     if (!fMerkleVerified)
     {
-        if (CBlock::CheckMerkleBranch(GetHash(), vMerkleBranch, nIndex) != pindex->hashMerkleRoot)
+        if (CBlock::CheckMerkleBranch(GetScriptSigHash(), vMerkleBranch, nIndex) != pindex->hashMerkleRoot)
             return 0;
         fMerkleVerified = true;
     }


### PR DESCRIPTION
When calculating a txid after Sapling upgrade , it does not include scriptsig field.
Note that
- Merkletree uses hashes including scriptsig.
- Txid of coinbase tx includes scriptsig.