### PR TITLE
Cleanup of the switch from yescrypt to yespower

### DIFF
--- a/src/sysendian.h
+++ b/src/sysendian.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2007-2009 Colin Percival
+ * Copyright 2007-2014 Colin Percival
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,37 +22,31 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- *
- * This file was originally written by Colin Percival as part of the Tarsnap
- * online backup system.
  */
+
 #ifndef _SYSENDIAN_H_
 #define _SYSENDIAN_H_
 
-/* If we don't have be64enc, the <sys/endian.h> we have isn't usable. */
-#if !HAVE_DECL_BE64ENC
-#undef HAVE_SYS_ENDIAN_H
-#endif
-
-#ifdef HAVE_SYS_ENDIAN_H
-
-#include <sys/endian.h>
-
-#else
-
 #include <stdint.h>
 
+/* Avoid namespace collisions with BSD <sys/endian.h>. */
+#define be32dec libcperciva_be32dec
+#define be32enc libcperciva_be32enc
+#define be64enc libcperciva_be64enc
+#define le32dec libcperciva_le32dec
+#define le32enc libcperciva_le32enc
+
 static inline uint32_t
-be32dec(const void *pp)
+be32dec(const void * pp)
 {
-	const uint8_t *p = (uint8_t const *)pp;
+	const uint8_t * p = (uint8_t const *)pp;
 
 	return ((uint32_t)(p[3]) + ((uint32_t)(p[2]) << 8) +
 	    ((uint32_t)(p[1]) << 16) + ((uint32_t)(p[0]) << 24));
 }
 
 static inline void
-be32enc(void *pp, uint32_t x)
+be32enc(void * pp, uint32_t x)
 {
 	uint8_t * p = (uint8_t *)pp;
 
@@ -62,19 +56,8 @@ be32enc(void *pp, uint32_t x)
 	p[0] = (x >> 24) & 0xff;
 }
 
-static inline uint64_t
-be64dec(const void *pp)
-{
-	const uint8_t *p = (uint8_t const *)pp;
-
-	return ((uint64_t)(p[7]) + ((uint64_t)(p[6]) << 8) +
-	    ((uint64_t)(p[5]) << 16) + ((uint64_t)(p[4]) << 24) +
-	    ((uint64_t)(p[3]) << 32) + ((uint64_t)(p[2]) << 40) +
-	    ((uint64_t)(p[1]) << 48) + ((uint64_t)(p[0]) << 56));
-}
-
 static inline void
-be64enc(void *pp, uint64_t x)
+be64enc(void * pp, uint64_t x)
 {
 	uint8_t * p = (uint8_t *)pp;
 
@@ -89,16 +72,16 @@ be64enc(void *pp, uint64_t x)
 }
 
 static inline uint32_t
-le32dec(const void *pp)
+le32dec(const void * pp)
 {
-	const uint8_t *p = (uint8_t const *)pp;
+	const uint8_t * p = (uint8_t const *)pp;
 
 	return ((uint32_t)(p[0]) + ((uint32_t)(p[1]) << 8) +
 	    ((uint32_t)(p[2]) << 16) + ((uint32_t)(p[3]) << 24));
 }
 
 static inline void
-le32enc(void *pp, uint32_t x)
+le32enc(void * pp, uint32_t x)
 {
 	uint8_t * p = (uint8_t *)pp;
 
@@ -107,32 +90,5 @@ le32enc(void *pp, uint32_t x)
 	p[2] = (x >> 16) & 0xff;
 	p[3] = (x >> 24) & 0xff;
 }
-
-static inline uint64_t
-le64dec(const void *pp)
-{
-	const uint8_t *p = (uint8_t const *)pp;
-
-	return ((uint64_t)(p[0]) + ((uint64_t)(p[1]) << 8) +
-	    ((uint64_t)(p[2]) << 16) + ((uint64_t)(p[3]) << 24) +
-	    ((uint64_t)(p[4]) << 32) + ((uint64_t)(p[5]) << 40) +
-	    ((uint64_t)(p[6]) << 48) + ((uint64_t)(p[7]) << 56));
-}
-
-static inline void
-le64enc(void *pp, uint64_t x)
-{
-	uint8_t * p = (uint8_t *)pp;
-
-	p[0] = x & 0xff;
-	p[1] = (x >> 8) & 0xff;
-	p[2] = (x >> 16) & 0xff;
-	p[3] = (x >> 24) & 0xff;
-	p[4] = (x >> 32) & 0xff;
-	p[5] = (x >> 40) & 0xff;
-	p[6] = (x >> 48) & 0xff;
-	p[7] = (x >> 56) & 0xff;
-}
-#endif /* !HAVE_SYS_ENDIAN_H */
 
 #endif /* !_SYSENDIAN_H_ */

--- a/src/yespower-opt.c
+++ b/src/yespower-opt.c
@@ -496,8 +496,7 @@ typedef struct {
 	((uint64_t)(uint32_t)_mm_cvtsi128_si32(HI32(X)) << 32))
 #endif
 
-//#if defined(__x86_64__) && (defined(__AVX__) || !defined(__GNUC__))
-#if 0 /* XXX The follwoing code is slower XXX */
+#if defined(__x86_64__) && (defined(__AVX__) || !defined(__GNUC__))
 /* 64-bit with AVX */
 /* Force use of 64-bit AND instead of two 32-bit ANDs */
 #undef DECL_SMASK2REG

--- a/src/yespower.c
+++ b/src/yespower.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2013-2018 Alexander Peslyak
+ * Copyright (c) 2018 The Koto developers
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/yespower.c
+++ b/src/yespower.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdlib.h> /* for abort() */
 
 #include "yespower.h"
 
@@ -33,5 +34,6 @@ void yespower_hash(const char *input, size_t inputlen, char *output)
 		.pers = (const uint8_t *)input,
 		.perslen = inputlen
 	};
-	yespower_tls((unsigned char *)input, inputlen, &params, (yespower_binary_t *)output);
+	if (yespower_tls((unsigned char *)input, inputlen, &params, (yespower_binary_t *)output))
+		abort();
 }

--- a/src/yespower.h
+++ b/src/yespower.h
@@ -37,6 +37,9 @@
 extern "C" {
 #endif
 
+/**
+ * yespower_hash() is a Koto addition, not part of yespower proper.
+ */
 extern void yespower_hash(const char *input, size_t inputlen, char *output);
 
 /**


### PR DESCRIPTION
I thought I'd only drop the misattribution from `yespower.h` and fix the dangerous bug of failing to check `yespower_tls()` return value, but I ended up noticing and fixing other issues as well.

Two things I left as-is for now for not knowing their rationale:

1. Why does `sha256.h` have `extern "C" {` ... `}` dropped? It has those in yespower 1.0, and nested ones are meant to work OK: https://stackoverflow.com/questions/48099828/what-happens-if-you-nest-extern-c

2. Why does `yespower-opt.c` has `#undef unlikely` added, and why only in the GCC-specific branch? At least the latter is probably a bug: if this name was somehow a previously defined macro, then it probably needs to be undefined for non-GCC as well. But I didn't find any other code in the tree that would define this macro.